### PR TITLE
Fix building with recent sdk

### DIFF
--- a/arduino_libs/httpd/httpServer.h
+++ b/arduino_libs/httpd/httpServer.h
@@ -137,7 +137,7 @@ void HttpServer::loop() {
 
   // Read data up to buffer length
   DEBUG_DUMP(bp);
-  bp += c.readBytes(buff + bp, min(sizeof(buff) - bp, av));
+  bp += c.readBytes(buff + bp, _min(sizeof(buff) - bp, av));
   DEBUG(Serial.print("Buffer state ["));
   DEBUG(Serial.write(buff, bp));
   DEBUG(Serial.println("]"));

--- a/c2_prog_wifi.ino
+++ b/c2_prog_wifi.ino
@@ -27,18 +27,16 @@ const char *c2_print_status_by_name(uint8_t ch) {
 //////////////////////
 class HelloWorldPage : public HttpServerPage {
     void onEndOfHeader() {
-      c->write("<!DOCTYPE html>\
-<html>\
-<body>\
-\
-<form action=\"upload\" method=\"post\" enctype=\"multipart/form-data\">\
-    Select image to upload:\
-    <input type=\"file\" name=\"fileToUpload\" id=\"fileToUpload\">\
-    <input type=\"submit\" value=\"Upload Image\" name=\"submit\">\
-</form>\
-\
-</body>\
-</html>");
+      c->write("<!DOCTYPE html>"
+               "<html>"
+               "<body>"
+               "<form action=\"upload\" method=\"post\" enctype=\"multipart/form-data\">"
+               "Select image to upload:"
+               "<input type=\"file\" name=\"fileToUpload\" id=\"fileToUpload\">"
+               "<input type=\"submit\" value=\"Upload Image\" name=\"submit\">"
+               "</form>"
+               "</body>"
+               "</html>");
       c->stop();
     }
 } helloWorldPage;


### PR DESCRIPTION
Should fix #2 
Tried this with sdk 2.3.0 (platformio 1.5.0)

Since [dfcaa1b](https://github.com/esp8266/Arduino/commit/dfcaa1b85464f16156d0920dd6ddff5697ac13dc#diff-3f18d8369c9b4d61f66060edc78243bb) sdk replaces `min` with `std::min`, but `_min` is exactly the same thing and is still there.