### PR TITLE
Add device specific initialization

### DIFF
--- a/arduino_libs/c2_prog/c2.cpp
+++ b/arduino_libs/c2_prog/c2.cpp
@@ -200,13 +200,33 @@ uint8_t c2_reset() {
   return C2_SUCCESS;
 }
 
-uint8_t c2_programming_init() {
+uint8_t c2_programming_init(uint8_t devid) {
   c2_reset();
   c2_address_write(C2FPCTL);
   C2_DATA_WRITE_AND_CHECK(C2FPCTL_ENABLE0,   1);
   C2_DATA_WRITE_AND_CHECK(C2FPCTL_CORE_HALT, 1);
   C2_DATA_WRITE_AND_CHECK(C2FPCTL_ENABLE1,   1)
   C2_DELAY_MS(21);
+
+  // device specific initialization, see https://www.silabs.com/documents/public/application-notes/AN127.pdf
+  switch (devid) {
+  case C2_DEVID_UNKNOWN:
+    break;
+  case C2_DEVID_EFM8BB1:
+  case C2_DEVID_EFM8BB2:
+  case C2_DEVID_EFM8BB3:	// C2_DEVID_EFM8LB1 is the same
+    c2_address_write(0xFF);
+    C2_DATA_WRITE_AND_CHECK(0x80, 1);
+    C2_DELAY_US(5);
+    c2_address_write(0xEF);
+    C2_DATA_WRITE_AND_CHECK(0x02, 1);
+    c2_address_write(0xA9);
+    C2_DATA_WRITE_AND_CHECK(0x00, 1);
+    break;
+  default:
+    return C2_BROKEN_LINK;
+  }
+
   return C2_SUCCESS;
 }
 

--- a/arduino_libs/c2_prog/c2.h
+++ b/arduino_libs/c2_prog/c2.h
@@ -102,6 +102,13 @@ inline void C2D_enable(bool oe) {
 #define C2_INBUSY   0x02
 #define C2_OUTREADY 0x01
 
+// Device families (https://www.silabs.com/documents/public/application-notes/AN127.pdf)
+#define	C2_DEVID_UNKNOWN	0x00
+#define	C2_DEVID_EFM8BB1	0x30
+#define	C2_DEVID_EFM8BB2	0x32
+#define	C2_DEVID_EFM8BB3	0x34
+#define	C2_DEVID_EFM8LB1	0x34
+
 // Layer 1: C2 Programmig Interface (PI) Register access
 void c2_address_write(uint8_t address);
 uint8_t c2_address_read();
@@ -124,7 +131,7 @@ inline uint8_t c2_data_read(uint8_t &d, uint8_t bytes=1) {
 
 // Layer 2: Operations
 uint8_t c2_reset();
-uint8_t c2_programming_init();
+uint8_t c2_programming_init(uint8_t devid);
 uint8_t c2_block_write(uint32_t address, uint8_t *data, uint8_t len);
 uint8_t c2_block_read(uint32_t address, uint8_t *data, uint8_t len);
 uint8_t c2_eeprom_read(uint32_t address, uint8_t *data, uint8_t len);

--- a/c2_prog_wifi.ino
+++ b/c2_prog_wifi.ino
@@ -93,6 +93,8 @@ class EchoPage : public HttpServerPage {
 //////////////////////
 class UploadPage : public HttpServerPage {
     bool headerprinted;
+    uint8_t devid;
+    uint8_t revid;
     void onConnect(WiFiClient &client, const char *sub, const char *hash) {
       HttpServerPage::onConnect(client,sub,hash);
       c->print("HTTP/1.1 200 OK\r\n");
@@ -103,7 +105,7 @@ class UploadPage : public HttpServerPage {
     void onEndOfHeader() {
       uint8_t err;
       c->print("<pre>Enable programming mode: ");
-      err = c2_programming_init();
+      err = c2_programming_init(C2_DEVID_UNKNOWN);
       c->println(c2_print_status_by_name(err));
       if (err != C2_SUCCESS) {
         c->stop();
@@ -111,8 +113,7 @@ class UploadPage : public HttpServerPage {
       }
 
       c->print("Device ID: ");
-      uint8_t devid;
-      err = c2_programming_init();
+      err = c2_programming_init(C2_DEVID_UNKNOWN);
       c2_address_write(C2DEVID);
       err = c2_data_read(devid, 1);
       if (err != C2_SUCCESS) {
@@ -124,8 +125,7 @@ class UploadPage : public HttpServerPage {
       c->println(devid, HEX);
 
       c->print("Revision ID: ");
-      uint8_t revid;
-      err = c2_programming_init();
+      err = c2_programming_init(C2_DEVID_UNKNOWN);
       c2_address_write(C2REVID);
       err = c2_data_read(revid, 1);
       if (err != C2_SUCCESS) {
@@ -137,7 +137,7 @@ class UploadPage : public HttpServerPage {
       c->println(revid, HEX);
 
       c->print("Erase flash: ");
-      err = c2_programming_init();
+      err = c2_programming_init(devid);
       err = c2_device_erase();
       c->println(c2_print_status_by_name(err));
       if (err != C2_SUCCESS) {
@@ -168,7 +168,7 @@ class UploadPage : public HttpServerPage {
         c->print  (": ");
         int retries = 5;
         do {
-          err = c2_programming_init();
+          err = c2_programming_init(devid);
           err = c2_block_write(address, h->data, h->len);
         } while (err != C2_SUCCESS && retries--);
         c->println(c2_print_status_by_name(err));


### PR DESCRIPTION
Without device specific initialization the flash erase and write operations are quite unstable. After a failed flash write attempt, my EFM8BB1 just refused every device erase command. I thought I had bricked my MCU.

Following [this thread](https://www.silabs.com/community/mcu/8-bit/forum.topic.html/how_to_unbrick_aloc-NFNi) I've found the solution: add the missing device specific initialization defined in [AN127 table 3.6](https://www.silabs.com/documents/public/application-notes/AN127.pdf).